### PR TITLE
Pre-compile SQF / Enable SQFC support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ texHeaders.bin
 *.biprivatekey
 Thumbs.db
 *.exe
+
+ArmaScriptCompiler.pdb
+libcsqfvm.dll

--- a/addons/main/CfgEventHandlers.hpp
+++ b/addons/main/CfgEventHandlers.hpp
@@ -1,17 +1,17 @@
 class Extended_PreStart_EventHandlers {
     class ADDON {
-        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));
     };
 };
 
 class Extended_PreInit_EventHandlers {
     class ADDON {
-        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
     };
 };
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
     };
 };

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,1 @@
+hemtt build --release

--- a/build_sqfc.bat
+++ b/build_sqfc.bat
@@ -1,0 +1,10 @@
+@echo off
+
+echo "STEP: Compile Arma Scripts"
+.\ArmaScriptCompiler.exe
+
+echo "STEP: Build using HEMTT"
+hemtt build --release
+
+echo "STEP: Cleanup *.sqfc files"
+powershell -Command Remove-Item './addons/*' -Recurse -Include *.sqfc

--- a/hemtt.toml
+++ b/hemtt.toml
@@ -13,12 +13,23 @@ files = [
     "meta.cpp"
 ]
 
-key_name = "{{prefix}}_{{version}}"
-authority = "{{prefix}}_{{version}}-{{git \"id 8\"}}"
-
 include = [
     "./include"
 ]
+
+exclude = [
+    "*.psd",
+    "*.png",
+    "*.tga"
+]
+
+key_name = "{{prefix}}_{{version}}"
+authority = "{{prefix}}_{{version}}-{{git \"id 8\"}}"
+sig_version = 3
+
+# ArmaScriptCompiler steps (Disabled until HEMTT supports signing PBOs with *.sfqc files)
+#prebuild = ["!compile_scripts"]
+#postbuild = ["!remove_compiled_scripts"]
 
 releasebuild = [
     "@zip bocr_{{semver.major}}.{{semver.minor}}.{{semver.patch}}"
@@ -26,3 +37,19 @@ releasebuild = [
 
 [header_exts]
 version= "{{git \"id 8\"}}"
+
+[scripts.compile_scripts]
+steps_windows = [
+    "echo STEP: Compile Arma Scripts",
+    "ArmaScriptCompiler"
+]
+only_release = false
+show_output = true
+
+[scripts.remove_compiled_scripts]
+steps_windows = [
+    "echo STEP: Remove Compiled Scripts (*.sqfc)",
+    "powershell -Command Remove-Item './addons/*' -Recurse -Include *.sqfc"
+]
+only_release = false
+show_output = true

--- a/sqfc.json
+++ b/sqfc.json
@@ -1,0 +1,9 @@
+{
+    "inputDirs": ["P:/x/bocr/addons"],
+    "includePaths": ["P:/"],
+    "excludeList": [
+        "initsettings.sqf"
+    ],
+    "outputDir": "P:/",
+    "workerThreads": 0
+}


### PR DESCRIPTION
**When merged this pull request will:**
- Add .bat files for building with and without sqfc (Requires development version of HEMTT supporting sqfc and installed ArmaScriptCompiler)
- Adjust hemtt.toml instructions to support sqfc
- Switch to `COMPILE_SCRIPT` macros instead of `COMPILE_FILE` for CBA XEH inits

**Required build utilities / repositories for using build_sqfc.bat:**
- Latest build from [dedmen/ArmaScriptCompiler](https://github.com/dedmen/ArmaScriptCompiler)
- Development version of HEMTTwith experimental sqfc support (can be gotten from ACE3 Public Slack)