### PR TITLE
Add API to blacklist variables from transfer

### DIFF
--- a/addons/main/functions/fnc_actionOnChest.sqf
+++ b/addons/main/functions/fnc_actionOnChest.sqf
@@ -26,7 +26,7 @@ private _backpackVariables = [];
 {
     private _val = (backpackContainer _unit) getVariable _x;
     _backpackVariables pushBack [_x, _val];
-} forEach (allVariables (backpackContainer _unit));
+} forEach ((allVariables (backpackContainer _unit) - GVAR(VarBlacklist)));
 
 [_unit, _backpack, _backpackLoadout, _backpackVariables, _backpackLoad] call FUNC(addChestpack);
 

--- a/addons/main/functions/fnc_actionSwap.sqf
+++ b/addons/main/functions/fnc_actionSwap.sqf
@@ -32,7 +32,7 @@ if ((_backpack isEqualTo "") or ([_unit] call FUNC(chestpack)) isEqualTo "") exi
 {
     private _val = (backpackContainer _unit) getVariable _x;
     _backpackVariables pushback [_x, _val];
-} forEach } forEach ((allVariables (backpackContainer _unit) - GVAR(VarBlacklist)));
+} forEach ((allVariables (backpackContainer _unit) - GVAR(VarBlacklist)));
 
 //remove packs
 [_unit] call FUNC(removeChestpack);

--- a/addons/main/functions/fnc_actionSwap.sqf
+++ b/addons/main/functions/fnc_actionSwap.sqf
@@ -32,7 +32,7 @@ if ((_backpack isEqualTo "") or ([_unit] call FUNC(chestpack)) isEqualTo "") exi
 {
     private _val = (backpackContainer _unit) getVariable _x;
     _backpackVariables pushback [_x, _val];
-} forEach (allVariables (backpackContainer _unit));
+} forEach } forEach ((allVariables (backpackContainer _unit) - GVAR(VarBlacklist)));
 
 //remove packs
 [_unit] call FUNC(removeChestpack);

--- a/addons/main/initSettings.sqf
+++ b/addons/main/initSettings.sqf
@@ -15,3 +15,8 @@
     true, // default value
     true // isGlobal
 ] call CBA_fnc_addSetting;
+
+// Blacklisted variables for mods that don't want variables to be transferred. Useful for very particular cases.
+GVAR(VarBlacklist) = [
+
+];


### PR DESCRIPTION

**When merged this pull request will:**
- Add a new GVAR VarBlacklist for exceptions to variable transfer
- Useful if a pfh handle being nil is used to detect presence of pfh on backpackContainer
