### PR TITLE
Better preserve state on switch

### DIFF
--- a/addons/main/functions/fnc_actionOnBack.sqf
+++ b/addons/main/functions/fnc_actionOnBack.sqf
@@ -20,13 +20,18 @@ private _chestpack = [_unit] call FUNC(chestpack);
 private _chestpackLoadout = [_unit] call FUNC(chestpackLoadout);
 private _chestpackVariables = [_unit] call FUNC(chestpackVariables);
 
+private _shouldSwitchNVGs = currentVisionMode _unit != 0;
+
 //make sure the player has a chestpack and no backpack
 if ((_chestpack isEqualTo "") or !(backpack _unit isEqualTo "")) exitWith {};
 
 //add items
-private _loadout = getUnitLoadout _unit;
-_loadout set [5, [_chestpack, _chestpackLoadout]];
-_unit setUnitLoadout _loadout;
+private _loadout = [_unit] call CBA_fnc_getLoadout;
+(_loadout select 0) set [5, [_chestpack, _chestpackLoadout]];
+[_unit, _loadout] call CBA_fnc_setLoadout;
+if (_shouldSwitchNVGs) then {
+    _unit action ["NVGoggles", _unit];
+};
 //prefilled versions of backpacks (ammo bearer, engineer, explosives, medic, repair, etc)
 //can be emptied and placed in unit's backpack
 //they must each be emptied when added

--- a/addons/main/functions/fnc_actionSwap.sqf
+++ b/addons/main/functions/fnc_actionSwap.sqf
@@ -25,6 +25,8 @@ private _chestpack = [_unit] call FUNC(chestpack);
 private _chestpackLoadout = [_unit] call FUNC(chestpackLoadout);
 private _chestpackVariables = [_unit] call FUNC(chestpackVariables);
 
+private _shouldSwitchNVGs = currentVisionMode _unit != 0;
+
 //make sure the player has chest-pack and backpack
 if ((_backpack isEqualTo "") or ([_unit] call FUNC(chestpack)) isEqualTo "") exitWith {};
 
@@ -39,9 +41,12 @@ if ((_backpack isEqualTo "") or ([_unit] call FUNC(chestpack)) isEqualTo "") exi
 removeBackpackGlobal _unit;
 
 //add backpack loadout
-private _loadout = getUnitLoadout _unit;
-_loadout set [5, [_chestpack, _chestpackLoadout]];
-_unit setUnitLoadout _loadout;
+private _loadout = [_unit] call CBA_fnc_getLoadout;
+(_loadout select 0) set [5, [_chestpack, _chestpackLoadout]];
+[_unit, _loadout] call CBA_fnc_setLoadout;
+if (_shouldSwitchNVGs) then {
+    _unit action ["NVGoggles", _unit];
+};
 
 //add backpack variables
 private _backpackNew = backpackContainer _unit;


### PR DESCRIPTION
**When merged this pull request will:**

- Switch to CBA functions for changing unit loadout, preserving extended gear data
- Use `action` to re-enable a unit's NVGs if they previously were using them
