### PR TITLE
Revert to vanilla loadout functions, re-apply ACEAX textures on switch

### DIFF
--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -43,6 +43,8 @@ if (isServer) then {
     }] call CBA_fnc_addEventHandler;
 };
 
+GVAR(isACEAXLoaded) = isClass (configFile >> "CfgPatches" >> "aceax_gearinfo");
+
 // Backpack classnames which will be made invisible instead of being made a chestpack. Useful for items like the vanilla legstrap.
 GVAR(exceptions) = [
     "B_LegStrapBag_black_F",

--- a/addons/main/functions/fnc_actionOnBack.sqf
+++ b/addons/main/functions/fnc_actionOnBack.sqf
@@ -26,9 +26,14 @@ private _shouldSwitchNVGs = currentVisionMode _unit != 0;
 if ((_chestpack isEqualTo "") or (backpack _unit isNotEqualTo "")) exitWith {};
 
 //add items
-private _loadout = [_unit] call CBA_fnc_getLoadout;
-(_loadout select 0) set [5, [_chestpack, _chestpackLoadout]];
-[_unit, _loadout] call CBA_fnc_setLoadout;
+private _loadout = getUnitLoadout _unit;
+_loadout set [5, [_chestpack, _chestpackLoadout]];
+_unit setUnitLoadout _loadout;
+
+if (GVAR(isACEAXLoaded)) then {
+    [_unit, [_unit] call aceax_gearinfo_fnc_getTextureOptions] call aceax_gearinfo_fnc_setTextureOptions;
+};
+
 if (_shouldSwitchNVGs) then {
     _unit action ["NVGoggles", _unit];
 };

--- a/addons/main/functions/fnc_actionSwap.sqf
+++ b/addons/main/functions/fnc_actionSwap.sqf
@@ -41,9 +41,14 @@ if ((_backpack isEqualTo "") or ([_unit] call FUNC(chestpack)) isEqualTo "") exi
 removeBackpackGlobal _unit;
 
 //add backpack loadout
-private _loadout = [_unit] call CBA_fnc_getLoadout;
-(_loadout select 0) set [5, [_chestpack, _chestpackLoadout]];
-[_unit, _loadout] call CBA_fnc_setLoadout;
+private _loadout = getUnitLoadout _unit;
+_loadout set [5, [_chestpack, _chestpackLoadout]];
+_unit setUnitLoadout _loadout;
+
+if (GVAR(isACEAXLoaded)) then {
+    [_unit, [_unit] call aceax_gearinfo_fnc_getTextureOptions] call aceax_gearinfo_fnc_setTextureOptions;
+};
+
 if (_shouldSwitchNVGs) then {
     _unit action ["NVGoggles", _unit];
 };


### PR DESCRIPTION
Upon further investigation, it seems the CBA loadout functions were not intended for "live" modifications of a unit's loadout, but instead for saving/loading loadouts for longer term storage, and so ACRE hooks the CBA `loadoutGet` and `loadoutSet` events to filter out radio states, which is not ideal.

This PR reverts usage of those functions back to the vanilla loadout functions, and instead will re-apply ACEAX texture options if ACEAX is loaded. Further custom handling may need to be considered for mods such as TFAR, as seen in [ACEAX's changeGear function](https://github.com/jetelain/AceArsenalExtended/blob/main/addons/ingame/functions/fnc_changeGear.sqf).